### PR TITLE
tirando Jop chato

### DIFF
--- a/src/Views/Screens/ScreenEmprestimos.java
+++ b/src/Views/Screens/ScreenEmprestimos.java
@@ -165,7 +165,6 @@ public class ScreenEmprestimos extends ScreenModel {
             new TelaCadastroEmprestimo(selectedLoan, ScreenSelectionType.SCREEN_TYPE_EDIT).setVisible(true);
         } catch (Exception e) {
             e.printStackTrace();
-            JOptionPane.showMessageDialog(null, e.getMessage());
         }
     }
 
@@ -200,7 +199,6 @@ public class ScreenEmprestimos extends ScreenModel {
             new TelaCadastroEmprestimo(selectedLoan, ScreenSelectionType.SCREEN_TYPE_VIEW).setVisible(true);
         } catch (Exception e) {
             e.printStackTrace();
-            JOptionPane.showMessageDialog(null, e.getMessage());
         }
     }
 

--- a/src/Views/Screens/ScreenFabricantes.java
+++ b/src/Views/Screens/ScreenFabricantes.java
@@ -158,7 +158,6 @@ public class ScreenFabricantes extends ScreenModel {
             new TelaCadastroFabricantes(selectedManufacturer, ScreenSelectionType.SCREEN_TYPE_EDIT).setVisible(true);
         } catch (Exception e) {
             e.printStackTrace();
-            JOptionPane.showMessageDialog(null, e.getMessage());
         }
     }
 
@@ -191,7 +190,6 @@ public class ScreenFabricantes extends ScreenModel {
             new TelaCadastroFabricantes(selectedManufacturer, ScreenSelectionType.SCREEN_TYPE_VIEW).setVisible(true);
         } catch (Exception e) {
             e.printStackTrace();
-            JOptionPane.showMessageDialog(null, e.getMessage());
         }
     }
 

--- a/src/Views/Screens/ScreenFerramentas.java
+++ b/src/Views/Screens/ScreenFerramentas.java
@@ -185,7 +185,6 @@ public class ScreenFerramentas extends ScreenModel {
             new TelaCadastroFerramentas(selectedTool, ScreenSelectionType.SCREEN_TYPE_EDIT).setVisible(true);
         } catch (Exception e) {
             e.printStackTrace();
-            JOptionPane.showMessageDialog(null, e.getMessage());
         }
     }
 
@@ -206,19 +205,7 @@ public class ScreenFerramentas extends ScreenModel {
             
             ToolsDAO.getInstance().removeTool(toolsDel);
             carregarDados();
-        } //        catch (ArrayIndexOutOfBoundsException e) {
-        //            JOptionPane.showMessageDialog(null, "Selecione alguma ferramenta primeiro");
-        //            e.printStackTrace();
-        //
-        //        } catch (DatabaseResultQueryException e) {
-        //            System.out.println("Talvez o banco de dados explodiu, mas não retornou nada");
-        //            e.printStackTrace();
-        //
-        //        } catch (SQLException e) {
-        //            System.out.println("Os comandos enviados SQL enviados tem algum problema");
-        //            e.printStackTrace();
-        //
-        //        }
+        } 
         catch (Exception e) {
             e.printStackTrace();
         }
@@ -231,7 +218,6 @@ public class ScreenFerramentas extends ScreenModel {
             new TelaCadastroFerramentas(selectedTool, ScreenSelectionType.SCREEN_TYPE_VIEW).setVisible(true);
         } catch (Exception e) {
             e.printStackTrace();
-            JOptionPane.showMessageDialog(null, e.getMessage());
         }
     }
 


### PR DESCRIPTION
Removido o JOption pane quando você apertava o botão de editar ou de visualizar sem ter selecionando algo, nas telas de:
- fabricante
- ferramentas
- empréstimo